### PR TITLE
fix(app.py): stubbing vpc id with todo to replace before deploy

### DIFF
--- a/README_CDK.md
+++ b/README_CDK.md
@@ -40,6 +40,8 @@ You can also install the required dev-dependencies.
 $ pip install -r requirements-dev.txt
 ```
 
+NOTE: In `app.py`, you will need to replace `<SOME VPC ID>` with an AWS VPC ID to be able to deploy. 
+
 At this point you can now synthesize the CloudFormation template for this code.
 
 ```

--- a/app.py
+++ b/app.py
@@ -10,7 +10,7 @@ app = App()
 ProvisionFsxLustreStepFunctionStack(
     app,
     "provision-fsx-lustre-step-function",
-    vpc_id="vpc-0c224fab5e167df49"
+    vpc_id="<SOME VPC ID>" # TODO: replace this value what a vpc_id to be able to deploy
 )
 
 app.synth()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Stubbing VPC ID with note to replace in `app.py` prior to running `cdk deploy`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
