### PR TITLE
fix(python): used variables for vpoc and subnet ids

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,8 +25,8 @@ app = App()
 ProvisionFsxLustreStepFunctionStack(
     app,
     "provision-fsx-lustre-step-function",
-    vpc_id=REPLACE_THIS,
-    subnet_id=REPLACE_THIS,
+    vpc_id=vpc_id,
+    subnet_id=subnet_id,
     lambda_file_path=lambda_file_path,
     lambda_layer_file_path=lambda_layer_file_path,
 )


### PR DESCRIPTION
*Description of changes:*
missed changing variable in `app.py`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
